### PR TITLE
chore: change to class base

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,69 @@
 # Prisma Repo
+
 #### Generating repository pattern for Prisma ORM faster and easier
 
 ---
 
-# What is this?
+## :warning: Change to Class Base From Function Base :warning:
+
+Starting from version 0.3.0 instead of extending the class by creating the instance for each models, we decide to create an abstract class that use a lot of static functions/method so it can be use without creating the instance.
+
+## What is this?
+
 A package that will make your life easier for using Repository Pattern while using Prisma ORM
 
-# Why make this?
+## Why make this?
+
 I like to use repository pattern in Sequelize, but when I saw Prisma support TypeScript I fell in love with it. Unfortunately, it's hard to use a repository pattern in prisma and to fix those issue this package exists.
 
-# Should I use this?
-Depends on what you need, if you doesnt want to have a lot of hassle to code almost a same things for all your services, then you dont need this package. But, if you are someone who doesn't want to struggle to build your own way to use the repository pattern in Prisma or if you just as lazy as me to generate the same repository for each models, then this package is for you.
+## Should I use this?
 
+Depends on what you need, if you doesnt care to have a lot of hassle to code almost a same things for all your services, then you dont need this package. But, if you are someone who doesn't want to struggle to build your own way to use the repository pattern in Prisma or if you just as lazy as me to generate the same repository for each models, then this package is for you.
 
-# How to use
+## How to use
+
 1. Install prisma-repo as dev dependencies
+
 ```
 npm i -D prisma-repo
 ```
+
 2. Generate all the repositories
+
 ```
 npx prisma-repo --repositories
 ```
 
-# Flags
-* Generate all repositories
+## Flags
+
+- Generate all repositories
+
 ```
 npx prisma-repo --repositories
 ```
 
-* Generate model structures files
+- Generate model structures files
+
 ```
 npx prisma-repo --model-structures
 ```
 
-* Generate the base repository only
+- Generate the base repository only
+
 ```
 npx prisma-repo --base-repository
 ```
 
-* Generate specific model repository
+- Generate specific model repository
+
 ```
 npx prisma-repo --modelname <model-name>
 ```
 
+## Config files
 
-# Config files
-## Accepted File Name/Formats
+### Accepted File Name/Formats
+
 ```
 repository.setting.json
 
@@ -55,7 +72,8 @@ repository.setting.js
 repository.setting.ts
 ```
 
-## Config files settings (JavaScript)
+### Config files settings (JavaScript)
+
 ```js
 // Language: javascript
 // Path: repository.setting.js
@@ -71,7 +89,8 @@ const config = {
 module.exports = config;
 ```
 
-## Config files settings (TypeScript)
+### Config files settings (TypeScript)
+
 ```ts
 // Language: typescript
 // Path: repository.setting.ts
@@ -89,7 +108,8 @@ const config: PrismaRepoConfig = {
 export default config;
 ```
 
-## Config files settings (JSON)
+### Config files settings (JSON)
+
 ```json
 // Path: repository.setting.json
 
@@ -98,16 +118,19 @@ export default config;
   "overwrite": false, // default false
   "repositoryPath": "src/repository", // default 'src/repository'
   "typesPath": "src/types", // default 'src/types'
-  "prismaLogger": true, // default false
+  "prismaLogger": true // default false
 }
 ```
 
-## Problem with extendExpress options
+### Problem with extendExpress options
+
 When this enabled, it will extends request object in `express`. Problem that will happen if this was triggered is that it will conflict with other modules, if it was reserved words like `file` and `files` which conflicting with `multer`. Other thing to consider as well is that if you use `include` options in prisma and it will conflict with the types that we extend with `extendExpress` options.
 
-## Possible values
+### Possible values
+
 Will extends express Request interface so it can be extends with the models name like `req.user` or `req.users`
-``` ts
+
+```ts
 extendExpress: boolean | {
   include: string[]; // model types to Include
   exclude: string[]; // model types to Exclued
@@ -124,17 +147,21 @@ overwrite: boolean | {
   baseRepository: boolean;
 }
 ```
+
 Determine where to put the repository files. By default it will be in `src/repository`
 
 ```ts
-repositoryPath: string
+repositoryPath: string;
 ```
+
 Determine where to put the extended express definition files. By default it will be in `src/types`
 
 ```ts
-typesPath: string
+typesPath: string;
 ```
+
 Will enable logging in prisma instance in `models.ts`. By default it will not show any logger (`false`)
+
 ```ts
 prismaLogger: boolean | {
   query: boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prisma-repo",
-  "version": "0.2.8",
+  "version": "0.3.0",
   "description": "Generating repository pattern using Prisma ORM faster and easier",
   "main": "dist/index.mjs",
   "scripts": {

--- a/src/cli/repository.ts
+++ b/src/cli/repository.ts
@@ -5,7 +5,7 @@ import fs from 'fs-extra';
 import appRootPath from 'app-root-path';
 import { importer } from '../template/repository';
 import { checkIsShouldOverwrite, isModelExists } from '../utils/common';
-import { repositoryBuilder, repositoryExtendsBuilder } from '../utils/builder';
+import { repositoryBuilder } from '../utils/builder';
 import logger from '../utils/logger';
 import createModelStructures from './models';
 import createBaseRepository from './baseRepository';
@@ -34,12 +34,10 @@ const createRepository = async (prisma: string, modelName: string, settings: Pri
   try {
     let model = '';
 
-    model += `${importer.lodash}\n`;
     model += `${importer.types}\n`;
-    model += `${importer.factory}\n\n`;
+    model += `${importer.baseRepository}\n\n`;
 
-    model += `${repositoryBuilder(modelName)}\n\n`;
-    model += `${repositoryExtendsBuilder(modelName)}`;
+    model += `${repositoryBuilder(modelName)}\n`;
 
     if (!directoryExists) {
       await fs.mkdir(repositoryDirPath);

--- a/src/template/baseRepository.ts
+++ b/src/template/baseRepository.ts
@@ -5,9 +5,9 @@ import {
   PRISMA_TYPES,
   BASE_REPOSITORY_TYPE,
   TYPES_NAMES,
-  BASE_REPOSITORY_MODEL_NAME,
   BASE_REPOSITORY_BASE_TYPE,
   REPOSITORY_TYPE,
+  CLASS_NAME,
 } from '../utils/constants';
 
 const baseRepository = `/* eslint-disable @typescript-eslint/ban-ts-comment */
@@ -19,168 +19,168 @@ ${IMPORT_LIBRARY.PRISMA}
 import { ${INSTANCE_NAME.MODELS}, ${TYPES_NAMES.MODEL_NAME}, ${TYPES_NAMES.MODEL_STRUCTURE}, ${TYPES_NAMES.MODEL_SCALAR_FIELDS}, ${INTERFACE_NAME.ANY_RECORD}, ${INTERFACE_NAME.BASE_OPTION}, ${INTERFACE_NAME.FIND}, ${INTERFACE_NAME.COUNT_ARGS}, ${INTERFACE_NAME.AGGREGATE}, ${TYPES_NAMES.MODEL_TYPES} } from './models';
 
 /**
- * @param model - The model name
+ * @param modelName - The model name
  */
 
-export class BaseRepository<${BASE_REPOSITORY_BASE_TYPE.CONSTRUCTOR}> {
-  constructor(protected modelName: ${TYPES_NAMES.MODEL_NAME}) {
-    ${BASE_REPOSITORY_MODEL_NAME} = modelName;
-  }
+const ${CLASS_NAME.BASE_REPOSITORY} = <
+  ${BASE_REPOSITORY_TYPE.EXTEND_MODEL_NAME},
+  ${REPOSITORY_TYPE.WHERE} extends ${BASE_REPOSITORY_BASE_TYPE.WHERE},
+  ${REPOSITORY_TYPE.SELECT} extends ${BASE_REPOSITORY_BASE_TYPE.SELECT},
+  ${REPOSITORY_TYPE.INCLUDE} extends ${BASE_REPOSITORY_BASE_TYPE.INCLUDE},
+  ${REPOSITORY_TYPE.CREATE} extends ${BASE_REPOSITORY_BASE_TYPE.CREATE},
+  ${REPOSITORY_TYPE.UPDATE} extends ${BASE_REPOSITORY_BASE_TYPE.UPDATE},
+  ${REPOSITORY_TYPE.CURSOR} extends ${BASE_REPOSITORY_BASE_TYPE.CURSOR},
+  ${REPOSITORY_TYPE.ORDER} extends ${BASE_REPOSITORY_BASE_TYPE.ORDER},
+  ${REPOSITORY_TYPE.DELEGATE} extends ${BASE_REPOSITORY_BASE_TYPE.DELEGATE},
+  ${REPOSITORY_TYPE.SCALAR} extends ${BASE_REPOSITORY_BASE_TYPE.SCALAR},
+  ${REPOSITORY_TYPE.MODEL} extends ${BASE_REPOSITORY_TYPE.MODEL_STRUCTURE}
+>(modelName: T) => {
+  abstract class ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY} {
+    protected static modelName: T = modelName;
 
-  // eslint-disable-next-line class-methods-use-this
-  private extractCondition(conditions: ${REPOSITORY_TYPE.CURSOR} | ${BASE_REPOSITORY_TYPE.QUERY_CONDITIONS}) {
-    const dbCond = _.isObject(conditions) ? conditions : { id: _.toNumber(conditions) };
+    // eslint-disable-next-line class-methods-use-this
+    private static extractCondition(conditions: ${REPOSITORY_TYPE.CURSOR} | ${BASE_REPOSITORY_TYPE.QUERY_CONDITIONS}) {
+      const dbCond = _.isObject(conditions) ? conditions : { id: _.toNumber(conditions) };
 
-    return dbCond;
-  }
-
-  public async findAll(
-    conditions: ${BASE_REPOSITORY_TYPE.QUERY_CONDITIONS},
-    filterQueryParams: ${INTERFACE_NAME.ANY_RECORD} = {},
-    query: ${INTERFACE_NAME.ANY_RECORD} = {},
-    option: ${BASE_REPOSITORY_TYPE.FIND_OPTION} = {}
-  ) {
-    const limit = +(query.limit === 'all' ? 0 : _.get(query, 'limit', 10));
-    const offset = query.page && query.page > 0 ? limit * (query.page - 1) : 0;
-    const otherOptions = _.omit(query, ['limit', 'offset', 'page']);
-
-    const where = { ...this.extractCondition(conditions), ...filterQueryParams, ...otherOptions };
-
-    return {
-      // @ts-ignore
-      rows: (await this.model.findMany({
-        where,
-        ...option,
-        skip: offset,
-        ...(limit > 0 && { take: limit }),
-      })) as ${REPOSITORY_TYPE.MODEL}[],
-      /* @ts-ignore */
-      count: await this.count(where),
-    };
-  }
-
-  public async findOne(
-    conditions: ${BASE_REPOSITORY_TYPE.QUERY_CONDITIONS},
-    option: ${BASE_REPOSITORY_TYPE.FIND_OPTION} = {}
-  ) {
-    const where = this.extractCondition(conditions);
-
-    // @ts-ignore
-    return this.model.findFirst({ where, ...option }) as Promise<${REPOSITORY_TYPE.MODEL}>;
-  }
-
-  public async findUnique(
-    conditions: ${REPOSITORY_TYPE.CURSOR} | number | string,
-    option: ${BASE_REPOSITORY_TYPE.CREATE_UPDATE_OPTION} = {}
-  ) {
-    const where = this.extractCondition(conditions);
-
-    // @ts-ignore
-    return this.model.findUnique({ where, ...option }) as Promise<${REPOSITORY_TYPE.MODEL}>;
-  }
-
-  public async create(data: ${REPOSITORY_TYPE.CREATE}, option: ${BASE_REPOSITORY_TYPE.CREATE_UPDATE_OPTION} = {}) {
-    // @ts-ignore
-    return this.model.create({ data, ...option }) as Promise<${REPOSITORY_TYPE.MODEL}>;
-  }
-
-  public async update(
-    conditions: ${BASE_REPOSITORY_TYPE.QUERY_CONDITIONS},
-    data: ${BASE_REPOSITORY_TYPE.UPDATE_CREATE_PAYLOAD},
-    option: ${BASE_REPOSITORY_TYPE.CREATE_UPDATE_OPTION} = {}
-  ) {
-    const where = this.extractCondition(conditions);
-
-    // @ts-ignore
-    return this.model.update({ data, where, ...option }) as Promise<${REPOSITORY_TYPE.MODEL}>;
-  }
-
-  public async delete(conditions: ${BASE_REPOSITORY_TYPE.QUERY_CONDITIONS}) {
-    const where = this.extractCondition(conditions);
-
-    // @ts-ignore
-    return this.model.deleteMany({ where }) as Promise<${PRISMA_TYPES.BATCH_PAYLOAD}>;
-  }
-
-  public async deleteOne(conditions: ${BASE_REPOSITORY_TYPE.QUERY_CONDITIONS}) {
-    const where = this.extractCondition(conditions);
-
-    // @ts-ignore
-    return this.model.delete({ where }) as Promise<${REPOSITORY_TYPE.MODEL}>;
-  }
-
-  public async updateOrCreate(
-    conditions: ${BASE_REPOSITORY_TYPE.QUERY_CONDITIONS},
-    data: ${REPOSITORY_TYPE.CREATE},
-    option: ${BASE_REPOSITORY_TYPE.FIND_OPTION} = {}
-  ) {
-    const obj = await this.findOne(conditions, option);
-
-    if (obj) return this.update(conditions, data, option);
-
-    return this.create(data);
-  }
-
-  public async bulkCreate(data: ${BASE_REPOSITORY_TYPE.ENUMERABLE_CREATE}, skipDuplicates = true) {
-    // @ts-ignore
-    return this.model.createMany({ data, skipDuplicates }) as Promise<${PRISMA_TYPES.BATCH_PAYLOAD}>;
-  }
-
-  public async bulkUpdate(where: ${REPOSITORY_TYPE.WHERE}, data: ${BASE_REPOSITORY_TYPE.ENUMERABLE_UPDATE}) {
-    // @ts-ignore
-    return this.model.updateMany({ data, where }) as Promise<${PRISMA_TYPES.BATCH_PAYLOAD}>;
-  }
-
-  public async count(
-    conditions: ${BASE_REPOSITORY_TYPE.QUERY_CONDITIONS},
-    option: ${BASE_REPOSITORY_TYPE.COUNT_OPTION} = {}
-  ) {
-    const where = this.extractCondition(conditions);
-
-    // @ts-ignore
-    return this.model.count({ where, ...option }) as Promise<number>;
-  }
-
-  public aggregate(
-    conditions: ${BASE_REPOSITORY_TYPE.QUERY_CONDITIONS},
-    aggregator: ${BASE_REPOSITORY_TYPE.AGGREGATE},
-    option: ${BASE_REPOSITORY_TYPE.AGGREGATE_OPTION} = {}
-  ) {
-    // @ts-ignore
-    const aggregate = this.model.aggregate as Delegate['aggregate'];
-    const where = this.extractCondition(conditions);
-
-    if (_.isEmpty(aggregator)) {
-      // @ts-ignore
-      // eslint-disable-next-line no-param-reassign, no-underscore-dangle
-      aggregator._count = true;
+      return dbCond;
     }
 
-    // @ts-ignore
-    return aggregate({ where, ...aggregator, ...option }) as ReturnType<typeof aggregate>;
+    public static async findAll(
+      conditions: ${BASE_REPOSITORY_TYPE.QUERY_CONDITIONS},
+      filterQueryParams: ${INTERFACE_NAME.ANY_RECORD} = {},
+      query: ${INTERFACE_NAME.ANY_RECORD} = {},
+      option: ${BASE_REPOSITORY_TYPE.FIND_OPTION} = {}
+    ) {
+      const limit = +(query.limit === 'all' ? 0 : _.get(query, 'limit', 10));
+      const offset = query.page && query.page > 0 ? limit * (query.page - 1) : 0;
+      const otherOptions = _.omit(query, ['limit', 'offset', 'page']);
+
+      const where = { ...${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.extractCondition(conditions), ...filterQueryParams, ...otherOptions };
+
+      return {
+        // @ts-ignore
+        rows: (await ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.model.findMany({
+          where,
+          ...option,
+          skip: offset,
+          ...(limit > 0 && { take: limit }),
+        })) as ${REPOSITORY_TYPE.MODEL}[],
+        /* @ts-ignore */
+        count: await this.count(where),
+      };
+    }
+
+    public static async findOne(
+      conditions: ${BASE_REPOSITORY_TYPE.QUERY_CONDITIONS},
+      option: ${BASE_REPOSITORY_TYPE.FIND_OPTION} = {}
+    ) {
+      const where = ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.extractCondition(conditions);
+
+      // @ts-ignore
+      return ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.model.findFirst({ where, ...option }) as Promise<${REPOSITORY_TYPE.MODEL} | null>;
+    }
+
+    public static async findUnique(
+      conditions: ${REPOSITORY_TYPE.CURSOR} | number | string,
+      option: ${BASE_REPOSITORY_TYPE.CREATE_UPDATE_OPTION} = {}
+    ) {
+      const where = ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.extractCondition(conditions);
+
+      // @ts-ignore
+      return ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.model.findUnique({ where, ...option }) as Promise<${REPOSITORY_TYPE.MODEL} | null>;
+    }
+
+    public static async create(data: ${REPOSITORY_TYPE.CREATE}, option: ${BASE_REPOSITORY_TYPE.CREATE_UPDATE_OPTION} = {}) {
+      // @ts-ignore
+      return ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.model.create({ data, ...option }) as Promise<${REPOSITORY_TYPE.MODEL}>;
+    }
+
+    public static async update(
+      conditions: ${BASE_REPOSITORY_TYPE.QUERY_CONDITIONS},
+      data: ${BASE_REPOSITORY_TYPE.UPDATE_CREATE_PAYLOAD},
+      option: ${BASE_REPOSITORY_TYPE.CREATE_UPDATE_OPTION} = {}
+    ) {
+      const where = ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.extractCondition(conditions);
+
+      // @ts-ignore
+      return ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.model.update({ data, where, ...option }) as Promise<${REPOSITORY_TYPE.MODEL}>;
+    }
+
+    public static async delete(conditions: ${BASE_REPOSITORY_TYPE.QUERY_CONDITIONS}) {
+      const where = ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.extractCondition(conditions);
+
+      // @ts-ignore
+      return ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.model.deleteMany({ where }) as Promise<${PRISMA_TYPES.BATCH_PAYLOAD}>;
+    }
+
+    public static async deleteOne(conditions: ${BASE_REPOSITORY_TYPE.QUERY_CONDITIONS}) {
+      const where = ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.extractCondition(conditions);
+
+      // @ts-ignore
+      return ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.model.delete({ where }) as Promise<${REPOSITORY_TYPE.MODEL}>;
+    }
+
+    public static async updateOrCreate(
+      conditions: ${BASE_REPOSITORY_TYPE.QUERY_CONDITIONS},
+      data: ${REPOSITORY_TYPE.CREATE},
+      option: ${BASE_REPOSITORY_TYPE.FIND_OPTION} = {}
+    ) {
+      const obj = await ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.findOne(conditions, option);
+
+      if (obj) return ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.update(conditions, data, option);
+
+      return ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.create(data);
+    }
+
+    public static async bulkCreate(data: ${BASE_REPOSITORY_TYPE.ENUMERABLE_CREATE}, skipDuplicates = true) {
+      // @ts-ignore
+      return ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.model.createMany({ data, skipDuplicates }) as Promise<${PRISMA_TYPES.BATCH_PAYLOAD}>;
+    }
+
+    public static async bulkUpdate(where: ${REPOSITORY_TYPE.WHERE}, data: ${BASE_REPOSITORY_TYPE.ENUMERABLE_UPDATE}) {
+      // @ts-ignore
+      return ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.model.updateMany({ data, where }) as Promise<${PRISMA_TYPES.BATCH_PAYLOAD}>;
+    }
+
+    public static async count(
+      conditions: ${BASE_REPOSITORY_TYPE.QUERY_CONDITIONS},
+      option: ${BASE_REPOSITORY_TYPE.COUNT_OPTION} = {}
+    ) {
+      const where = ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.extractCondition(conditions);
+
+      // @ts-ignore
+      return ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.model.count({ where, ...option }) as Promise<number>;
+    }
+
+    public static aggregate(
+      conditions: ${BASE_REPOSITORY_TYPE.QUERY_CONDITIONS},
+      aggregator: ${BASE_REPOSITORY_TYPE.AGGREGATE},
+      option: ${BASE_REPOSITORY_TYPE.AGGREGATE_OPTION} = {}
+    ) {
+      // @ts-ignore
+      const aggregate = ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.model.aggregate as Delegate['aggregate'];
+      const where = ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.extractCondition(conditions);
+
+      if (_.isEmpty(aggregator)) {
+        // @ts-ignore
+        // eslint-disable-next-line no-param-reassign, no-underscore-dangle
+        aggregator._count = true;
+      }
+
+      // @ts-ignore
+      return aggregate({ where, ...aggregator, ...option }) as ReturnType<typeof aggregate>;
+    }
+
+    public static get model(): Delegate {
+      // @ts-ignore
+      return ${INSTANCE_NAME.MODELS}[${CLASS_NAME.ABSTRACT_BASE_REPOSITORY}.modelName];
+    }
   }
 
-  public get model(): Delegate {
-    // @ts-ignore
-    return ${INSTANCE_NAME.MODELS}[${BASE_REPOSITORY_MODEL_NAME}];
-  }
+  return ${CLASS_NAME.ABSTRACT_BASE_REPOSITORY};
 }
 
-const factory = <${BASE_REPOSITORY_TYPE.EXTEND_MODEL_NAME}>(model: T) =>
-  new BaseRepository<
-    ${BASE_REPOSITORY_BASE_TYPE.WHERE},
-    ${BASE_REPOSITORY_BASE_TYPE.SELECT},
-    ${BASE_REPOSITORY_BASE_TYPE.INCLUDE},
-    ${BASE_REPOSITORY_BASE_TYPE.CREATE},
-    ${BASE_REPOSITORY_BASE_TYPE.UPDATE},
-    ${BASE_REPOSITORY_BASE_TYPE.CURSOR},
-    ${BASE_REPOSITORY_BASE_TYPE.ORDER},
-    ${BASE_REPOSITORY_BASE_TYPE.DELEGATE},
-    ${BASE_REPOSITORY_BASE_TYPE.SCALAR},
-    ${BASE_REPOSITORY_TYPE.MODEL_STRUCTURE}
-  >(model);
-
-export default factory;
+export default ${CLASS_NAME.BASE_REPOSITORY};
 `;
 
 export default baseRepository;

--- a/src/template/repository.ts
+++ b/src/template/repository.ts
@@ -1,8 +1,8 @@
-import { IMPORT_LIBRARY, MODELS_CONSTANTS_NAMES } from '../utils/constants';
+import { CLASS_NAME, IMPORT_LIBRARY, MODELS_CONSTANTS_NAMES } from '../utils/constants';
 
 export const importer = {
   lodash: IMPORT_LIBRARY.LODASH,
   prisma: IMPORT_LIBRARY.PRISMA,
-  factory: `import factory from './baseRepository';`,
+  baseRepository: `import ${CLASS_NAME.BASE_REPOSITORY} from './baseRepository';`,
   types: `import { ${MODELS_CONSTANTS_NAMES} } from './models';`,
 } as const;

--- a/src/utils/builder.ts
+++ b/src/utils/builder.ts
@@ -1,15 +1,14 @@
 import _ from 'lodash';
 import { toConstantCase } from './common';
-import { MODELS_CONSTANTS_NAMES, REPOSITORY_TYPE, TYPES_NAMES } from './constants';
+import { CLASS_NAME, MODELS_CONSTANTS_NAMES, REPOSITORY_TYPE, TYPES_NAMES } from './constants';
 import { ExtendExpress, ModelTypes } from './interface';
 
-export const repositoryBuilder = <T extends string>(modelName: T) => {
-  const repositoryName = _.camelCase(`${modelName}Repository`);
+export const repositoryBuilder = <T extends string>(modelName: T) =>
+  `class ${modelName} extends ${
+    CLASS_NAME.BASE_REPOSITORY
+  }(${MODELS_CONSTANTS_NAMES}.${toConstantCase(modelName)}) {}
 
-  return `const ${repositoryName} = factory(${MODELS_CONSTANTS_NAMES}.${toConstantCase(
-    modelName
-  )});`;
-};
+export default ${modelName};`;
 
 export const repositoryExtendsBuilder = <T extends string>(modelName: T) => {
   const extendedRepository = `${_.camelCase(modelName)}Repository`;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -169,3 +169,8 @@ export const PRISMA_LOGGER = {
   WARN: 'warn',
   ERROR: 'error',
 } as const;
+
+export const CLASS_NAME = {
+  BASE_REPOSITORY: 'BaseRepository',
+  ABSTRACT_BASE_REPOSITORY: 'AbstractBaseRepository',
+} as const;


### PR DESCRIPTION
## :warning: Breaking Changes : Change to Class Base From Function Base :warning:

Starting from version 0.3.0 instead of extending the class by creating the instance for each models, we decide to create an abstract class that use a lot of static functions/method so it can be use without creating the instance.